### PR TITLE
Travis, README, and Begin conversion to Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: rust
+rust: nightly
+script:
+  - cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "core"
 version = "1.0.0"
-authors = ["Ben Harris <mail@bharr.is>", "Matt Ickstadt <matt@icky.pw>"]
+authors = ["Ben Harris <mail@bharr.is>", "Matt Ickstadt <matt@icky.pw>", "Matt Coffin <mcoffin13@gmail.com>"]
 build = "./build.rs"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+[![Build Status](https://travis-ci.org/hackndev/rust-libcore.svg#branch=master)](https://travis-ci.org/hackndev/rust-libcore) 
+
+# rust-libcore
+
+This crate provides `libcore` as a standalone cargo package.
+
+## Versioning
+
+`rust-libcore` will run `rustc --version` to determine the version of rustc that we are using. The version of libcore appropriate for the compiler will be used.

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,49 @@
 use std::process::Command;
+use std::env;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+const RUST_DIR: &'static str = "./rust";
+
+fn ensure_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    let path = path.as_ref();
+    match fs::read_dir(path) {
+        Ok(..) => Ok(()),
+        Err(..) => fs::create_dir(path),
+    }
+}
 
 fn main() {
+    // Ensure the rust directory exists
+    if let Err(e) = ensure_dir(RUST_DIR) {
+        panic!(e);
+    }
+
+    // cd to the rust directory
+    if let Err(e) = env::set_current_dir(RUST_DIR) {
+        panic!(e);
+    }
+
+    // Run rustc to get the version
+    let rustc_output = Command::new("rustc").arg("--version")
+        .output().unwrap_or_else(|e| {
+            panic!("failed to execute rustc: {}", e);
+        });
+    let output_bytes: &[u8] = rustc_output.stdout.as_ref();
+    let version = match std::str::from_utf8(output_bytes) {
+        Ok(s) => s.split(" ").nth(2).expect("rustc gave invalid version format"),
+        Err(e) => panic!(e),
+    }.trim_left_matches("(");
+
     // Shell out to perform the build.  In the future, the logic
     // to grab libcore could be done in rust in order to support
     // platforms without a posix shell
-	Command::new("sh").arg("./build.sh").status().unwrap_or_else(|e| {
-		panic!("failed to execute process: {}", e)
-    });
+    Command::new("sh")
+        .arg("../build.sh")
+        .env("DOWNLOAD_LINK",
+             format!("https://github.com/rust-lang/rust/tarball/{}", version))
+        .status().unwrap_or_else(|e| {
+            panic!("failed to execute process: {}", e);
+        });
 }

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,4 @@
 #!/bin/sh
-mkdir -p rust
-cd rust
-
-DOWNLOAD_LINK="https://github.com/rust-lang/rust/tarball/`rustc --version|awk '{sub(/\\(/, "", $3); print $3}'`"
-
 which wget >/dev/null 2>/dev/null
 if [ $? -eq 0 ]; then
   wget -q -O rust.tar.gz "$DOWNLOAD_LINK"


### PR DESCRIPTION
Following are obstacles in going _full_ rust, but this is at least a start and moves in the right direction
- unzip / untar capabilies for rust
- http download for rust

Now that we have CI & a REAME, someone should add a license. Then, when we get to 100% rust we can publish to `crates.io`.
